### PR TITLE
Add explicit android target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform) apply  false
     alias(libs.plugins.vanniktech.mavenPublish) apply false
+    alias(libs.plugins.android.library) apply false
 }
 
 //tasks.register("clean", Delete::class) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,10 @@
 kotlin = "2.1.10"
 serialization = "1.8.1"
 coroutines = "1.10.2"
+android = "8.13.0"
 
 buffer = "1.4.2"
-multimult = "0.2.4"
+multimult = "0.2.5"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -15,6 +16,7 @@ buffer = { module = "com.ditchoom:buffer", version.ref = "buffer" }
 multimult = { module = "io.github.funkatronics:multimult", version.ref = "multimult" }
 
 [plugins]
+android-library = {id = "com.android.library", version.ref="android" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 17 11:39:18 MDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kborsh/build.gradle.kts
+++ b/kborsh/build.gradle.kts
@@ -2,12 +2,22 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.plugin.serialization)
     alias(libs.plugins.vanniktech.mavenPublish)
+    alias(libs.plugins.android.library)
+}
+
+android {
+    namespace = "com.funkatronics.kborsh"
+    compileSdk = 35
+    defaultConfig { minSdk = 21 }
+    publishing { singleVariant("release") }
 }
 
 kotlin {
     jvmToolchain(11)
+
     jvm()
     androidTarget()
+
     listOf(
         iosX64(),
         iosArm64(),
@@ -19,7 +29,7 @@ kotlin {
             baseName = "kborsh"
         }
     }
-//    js(BOTH) {
+//    js {
 //        browser {
 //            commonWebpackConfig {
 //                cssSupport {
@@ -36,6 +46,8 @@ kotlin {
 //        isMingwX64 -> mingwX64("native")
 //        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
 //    }
+
+    applyDefaultHierarchyTemplate()
 
     sourceSets {
         val commonMain by getting {
@@ -56,34 +68,18 @@ kotlin {
             dependsOn(commonMain)
         }
 
-        val jvmMain by getting {
-            dependsOn(multiplatformMain)
-        }
-        val jvmTest by getting
+        val jvmMain by getting { dependsOn(multiplatformMain) }
+        val androidMain by getting { dependsOn(multiplatformMain) }
 
-        val androidMain by getting {
-            dependsOn(multiplatformMain)
-        }
-        val androidTest by getting
+        val iosX64Main by getting { dependsOn(multiplatformMain) }
+        val iosArm64Main by getting { dependsOn(multiplatformMain) }
+        val iosSimulatorArm64Main by getting { dependsOn(multiplatformMain) }
 
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosSimulatorArm64Main by getting
+        val macosX64Main by getting { dependsOn(multiplatformMain) }
+        val macosArm64Main by getting { dependsOn(multiplatformMain) }
 
-        iosX64Main.dependsOn(multiplatformMain)
-        iosArm64Main.dependsOn(multiplatformMain)
-        iosSimulatorArm64Main.dependsOn(multiplatformMain)
-
-        val macosX64Main by getting
-        val macosArm64Main by getting
-
-        macosX64Main.dependsOn(multiplatformMain)
-        macosArm64Main.dependsOn(multiplatformMain)
-
-//        val jsMain by getting
-//        val jsTest by getting
-//        val nativeMain by getting
-//        val nativeTest by getting
+//        val jsMain by getting { dependsOn(multiplatformMain) }
+//        val nativeMain by getting { dependsOn(multiplatformMain) }
     }
 }
 


### PR DESCRIPTION
Koltin 2.0 changed how android compilation works, we need to explicitly define an android target now. this will fix class not found exceptions on Android (#3)